### PR TITLE
removed buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster
+FROM python:3.8-slim
 
 RUN apt update && apt upgrade -y
 RUN apt install git -y


### PR DESCRIPTION
Docker file needs to be changed. From buster to bookworm or just nothing.

Why This Works
buster = Debian 10 → deprecated, repos removed

bookworm = Debian 12 → current stable, repos active

python:3.8-slim → auto-points to a supported Debian base