### PR TITLE
Docker file has to be changed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim-buster
+FROM python:3.8-slim
 
 RUN apt update && apt upgrade -y
 RUN apt install git -y

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
 FROM python:3.8-slim-bookworm
 
-RUN apt update && apt upgrade -y
-RUN apt install git -y
-COPY requirements.txt /requirements.txt
+RUN apt update && apt install -y git
 
-RUN cd /
-RUN pip3 install -U pip && pip3 install -U -r requirements.txt
+COPY requirements.txt /requirements.txt
+RUN pip3 install -U pip && pip3 install -U -r /requirements.txt
+
 RUN mkdir /TelegramBot
 WORKDIR /TelegramBot
 COPY start.sh /start.sh
+
 CMD ["/bin/bash", "/start.sh"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,12 @@
 FROM python:3.8-slim-bookworm
 
-RUN apt update && apt install -y git
-
+RUN apt update && apt upgrade -y
+RUN apt install git -y
 COPY requirements.txt /requirements.txt
-RUN pip3 install -U pip && pip3 install -U -r /requirements.txt
 
+RUN cd /
+RUN pip3 install -U pip && pip3 install -U -r requirements.txt
 RUN mkdir /TelegramBot
 WORKDIR /TelegramBot
 COPY start.sh /start.sh
-
 CMD ["/bin/bash", "/start.sh"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-slim
+FROM python:3.8-slim-bookworm
 
 RUN apt update && apt upgrade -y
 RUN apt install git -y


### PR DESCRIPTION
This line,
FROM python:3.8-slim-buster
Has to be changed to
FROM python:3.8-slim-bookworm

Why This Works
buster = Debian 10 → deprecated, repos removed

bookworm = Debian 12 → current stable, repos active

python:3.8-slim → auto-points to a supported Debian base

This problem occurs when trying to deploy to Heroku using the deploy button in the repo. It deploys using the original repo not the fork. So above is the solution